### PR TITLE
Fix deprecation warning for Socket.gethostbyname

### DIFF
--- a/check_gluster.rb
+++ b/check_gluster.rb
@@ -180,7 +180,7 @@ module CheckGluster
     def volume_status(volume, bricks, checks)
       nodes = gluster("volume status #{volume}")['volStatus']['volumes']['volume']['node']
       nodes = any_to_array(nodes)
-      nodes.each { |node| node['path'] = Socket.gethostbyname(Socket.gethostname).first if node['path'] == 'localhost' }
+      nodes.each { |node| node['path'] = Addrinfo.getaddrinfo(Socket.gethostname, 80).first if node['path'] == 'localhost' }
       # Check that all bricks are running
       bricks.each do |brick|
         raise "volume #{brick[0]}:#{brick[1]} is not running" unless check_running(nodes, brick[0], brick[1])


### PR DESCRIPTION
With recent versions of ruby, we get a deprecation warning on each call.

```
/usr/lib/nagios/plugins/check_gluster:183: warning: Socket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead.
```

To resolve the issue `Addrinfo.getaddrinfo` is used instead with port 80 as service parameter.